### PR TITLE
Transport: Compression added

### DIFF
--- a/frame/buffer.go
+++ b/frame/buffer.go
@@ -20,6 +20,10 @@ type Buffer struct {
 	readErr error
 }
 
+func (b *Buffer) BytesBuffer() *bytes.Buffer {
+	return &b.buf
+}
+
 func (b *Buffer) Bytes() []byte {
 	return b.buf.Bytes()
 }

--- a/frame/types.go
+++ b/frame/types.go
@@ -113,7 +113,7 @@ type ErrorCode = Int
 type HeaderFlags = Byte
 
 const (
-	Compression   HeaderFlags = 0x01
+	Compress      HeaderFlags = 0x01
 	Tracing       HeaderFlags = 0x02
 	CustomPayload HeaderFlags = 0x04
 	Warning       HeaderFlags = 0x08
@@ -263,6 +263,13 @@ var allSchemaChangeTargets = map[SchemaChangeTarget]struct{}{
 
 // https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L296-L308
 type StartupOptions StringMap
+
+type Compression string
+
+const (
+	Lz4    Compression = "lz4"
+	Snappy Compression = "snappy"
+)
 
 // Mandatory values and keys that can be given in Startup body
 // value in the map means option name and key means its possible values.

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/mmatczuk/scylla-go-driver
 go 1.18
 
 require (
-	github.com/google/btree v1.0.1
 	github.com/google/go-cmp v0.5.6
+	github.com/klauspost/compress v1.15.1
+	github.com/pierrec/lz4/v4 v4.1.14
 	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.12
 )
 
 require github.com/pkg/profile v1.6.0
-
-replace github.com/google/btree => github.com/Michal-Leszczynski/btree v1.0.2-0.20220412174850-ff8ccb34568a

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,15 @@
-github.com/Michal-Leszczynski/btree v1.0.2-0.20220412174850-ff8ccb34568a h1:SYg/9GAKVg7X2H/BVeBLuNblz5dzL8omAkGJz+hE5oM=
-github.com/Michal-Leszczynski/btree v1.0.2-0.20220412174850-ff8ccb34568a/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
+github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
+github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
 github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/query.go
+++ b/query.go
@@ -138,6 +138,14 @@ func (q *Query) PageSize() int32 {
 	return q.stmt.PageSize
 }
 
+func (q *Query) SetCompression(v bool) {
+	q.stmt.Compression = v
+}
+
+func (q *Query) Compression() bool {
+	return q.stmt.Compression
+}
+
 type Result transport.QueryResult
 
 func (q *Query) Iter() Iter {

--- a/session.go
+++ b/session.go
@@ -56,6 +56,13 @@ var (
 	errNoConnection = fmt.Errorf("no working connection")
 )
 
+type Compression = frame.Compression
+
+var (
+	Snappy Compression = frame.Snappy
+	Lz4    Compression = frame.Lz4
+)
+
 type SessionConfig struct {
 	Hosts  []string
 	Events []EventType

--- a/transport/compress.go
+++ b/transport/compress.go
@@ -1,0 +1,148 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/pierrec/lz4/v4"
+)
+
+var (
+	ErrComprCorrupt     = errors.New("compression: corrupt input")
+	ErrComprUnknown     = errors.New("compression: unknown algorithm")
+	errComprUnspecified = errors.New("compression: unspecified algorithm")
+)
+
+type compr struct {
+	buf    bytes.Buffer // Holds the data to compress/decompress from source
+	tmp    bytes.Buffer // Data should be (de)compressed to tmp before writing it to its destination.
+	header []byte
+
+	// codec compresses/decompresses read bytes from buf to tmp.
+	codec func(read int) (written int, err error)
+	// Used in lz4 encoding.
+	c lz4.Compressor
+}
+
+func (c *compr) compress(dst io.Writer, src *bytes.Buffer) (written int64, err error) {
+	c.buf = *src
+	buf := c.buf.Bytes()
+	read := len(c.buf.Bytes())
+
+	if read <= 9 {
+		nr, err := dst.Write(buf[:read])
+		return int64(nr), err
+	}
+	_ = copy(c.header, buf[:9])
+	c.header[1] |= frame.Compress
+
+	var n int
+	if n, err = c.codec(read); err != nil {
+		return 0, err
+	}
+
+	nrh, erh := dst.Write(c.header)
+	if erh != nil {
+		return int64(nrh), erh
+	}
+
+	nr, err := dst.Write(c.tmp.Bytes()[:n])
+	return int64(nr + nrh), err
+}
+
+func (c *compr) decompress(dst io.Writer, src *io.LimitedReader) (written int64, err error) {
+	c.buf.Reset()
+	read := int(src.N)
+
+	_, err = io.Copy(&c.buf, src)
+	if err != nil {
+		return 0, err
+	}
+
+	var n int
+	if n, err = c.codec(read); err != nil {
+		return 0, err
+	}
+
+	nr, err := dst.Write(c.tmp.Bytes()[:n])
+	return int64(nr), err
+}
+
+// newCompr returns a new compressor with respect to whether it should compress or decompress data.
+func newCompr(compress bool, algo frame.Compression, bufSize int) (*compr, error) {
+	c := new(compr)
+	c.buf.Grow(bufSize)
+	switch algo {
+	case frame.Snappy:
+		if compress {
+			c.codec = c.encodeSnappy
+			c.header = make([]byte, 9)
+			c.tmp.Grow(bufSize * bufSize / s2.MaxEncodedLen(bufSize))
+		} else {
+			c.codec = c.decodeSnappy
+			c.tmp.Grow(s2.MaxEncodedLen(bufSize))
+		}
+	case frame.Lz4:
+		if compress {
+			c.codec = c.encodeLz4
+			c.header = make([]byte, 9)
+			c.tmp.Grow(bufSize * bufSize / lz4.CompressBlockBound(bufSize))
+		} else {
+			c.codec = c.decodeLz4
+			c.tmp.Grow(lz4.CompressBlockBound(bufSize))
+		}
+	default:
+		return nil, ErrComprUnknown
+	}
+	return c, nil
+}
+
+func (c *compr) decodeSnappy(read int) (int, error) {
+	buf := c.buf.Bytes()
+	n, err := s2.DecodedLen(buf)
+	if err != nil {
+		return 0, err
+	}
+	c.tmp.Grow(n)
+	if _, err := s2.Decode(c.tmp.Bytes(), buf[:read]); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (c *compr) encodeSnappy(read int) (int, error) {
+	c.tmp.Grow(s2.MaxEncodedLen(read - 9))
+	enc := s2.EncodeSnappy(c.tmp.Bytes(), c.buf.Bytes()[9:read])
+	binary.BigEndian.PutUint32(c.header[5:9], uint32(len(enc)))
+	return len(enc), nil
+}
+
+func (c *compr) decodeLz4(read int) (int, error) {
+	if read < 4 {
+		return 0, ErrComprCorrupt
+	}
+
+	buf := c.buf.Bytes()
+	n := int(binary.BigEndian.Uint32(buf[0:4]))
+	c.tmp.Grow(n)
+	if _, err := lz4.UncompressBlock(buf[4:read], c.tmp.Bytes()[:n]); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (c *compr) encodeLz4(read int) (int, error) {
+	n := lz4.CompressBlockBound(read - 9)
+	c.tmp.Grow(n + 4)
+	n, err := c.c.CompressBlock(c.buf.Bytes()[9:read], c.tmp.Bytes()[4:(n+4)])
+	if n == 0 || err != nil {
+		return 0, ErrComprCorrupt
+	}
+	binary.BigEndian.PutUint32(c.tmp.Bytes()[:4], uint32(read)-9)
+	binary.BigEndian.PutUint32(c.header[5:9], uint32(n)+4)
+	return n + 4, nil
+}

--- a/transport/compress_test.go
+++ b/transport/compress_test.go
@@ -1,0 +1,158 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/pierrec/lz4/v4"
+)
+
+type comprData struct {
+	name             string
+	uncompressed     []byte
+	compressedSnappy []byte
+	compressedLz4    []byte
+}
+
+func getRandomBytes(n int) []byte {
+	out := make([]byte, n)
+	for i := 9; i < n; i++ {
+		out[i] = byte(rand.Intn(255))
+	}
+	return out
+}
+
+func TestCompression(t *testing.T) {
+	t.Parallel()
+	testCases := []comprData{
+		{
+			name:         "utf-8",
+			uncompressed: append(make([]byte, 9), []byte("Hello World! こんにちは世界! ¡Hola, Mundo!")...),
+		},
+		{
+			name:         "64kb",
+			uncompressed: getRandomBytes(1<<16 + 9),
+		},
+		{
+			name:         "1mb",
+			uncompressed: getRandomBytes(1<<20 + 9),
+		},
+		{
+			name:         "8mb",
+			uncompressed: getRandomBytes(1<<23 + 9),
+		},
+		{
+			name:         "64mb",
+			uncompressed: getRandomBytes(1<<26 + 9),
+		},
+		{
+			name:         "256mb",
+			uncompressed: getRandomBytes(1<<28 + 9),
+		},
+	}
+	for i, c := range testCases {
+		testCases[i].compressedSnappy = s2.Encode(nil, c.uncompressed[9:])
+		testCases[i].compressedLz4 = func() []byte {
+			in := make([]byte, lz4.CompressBlockBound(len(c.uncompressed)+4))
+			n, err := lz4.CompressBlock(c.uncompressed[9:], in[4:], nil)
+			binary.BigEndian.PutUint32(in, uint32(len(c.uncompressed))-9)
+			if err != nil {
+				t.Fatal("error in making test case", err)
+			}
+			return in[:n+4]
+		}()
+	}
+
+	ces := getCompression(t, true, frame.Snappy)
+	cds := getCompression(t, false, frame.Snappy)
+	cel := getCompression(t, true, frame.Lz4)
+	cdl := getCompression(t, false, frame.Lz4)
+
+	for i := 0; i < len(testCases); i++ {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Just created compr structs
+			testSnappy(t, getCompression(t, true, frame.Snappy), true, &tc)
+			testSnappy(t, getCompression(t, false, frame.Snappy), false, &tc)
+			testLz4(t, getCompression(t, true, frame.Lz4), true, &tc)
+			testLz4(t, getCompression(t, false, frame.Lz4), false, &tc)
+
+			// Long-running compr structs
+			testSnappy(t, ces, true, &tc)
+			testSnappy(t, cds, false, &tc)
+			testLz4(t, cel, true, &tc)
+			testLz4(t, cdl, false, &tc)
+		})
+	}
+}
+
+func getCompression(t *testing.T, compress bool, variant frame.Compression) *compr {
+	c, err := newCompr(compress, variant, comprBufferSize)
+	if err != nil {
+		t.Fatal("error in making compr struct", compress, frame.Lz4)
+	}
+	return c
+}
+
+func testSnappy(t *testing.T, c *compr, compress bool, data *comprData) {
+	if compress {
+		buf := *bytes.NewBuffer(data.uncompressed)
+		var in bytes.Buffer
+		testCompress(t, c, &in, &buf, data.compressedSnappy)
+	} else {
+		lr := io.LimitedReader{
+			R: bytes.NewBuffer(data.compressedSnappy),
+		}
+		lr.N = int64(len(data.compressedSnappy))
+		var in bytes.Buffer
+		testDecompress(t, c, &in, &lr, data.uncompressed)
+	}
+}
+
+func testLz4(t *testing.T, c *compr, compress bool, data *comprData) {
+	if compress {
+		buf := *bytes.NewBuffer(data.uncompressed)
+		var in bytes.Buffer
+		testCompress(t, c, &in, &buf, data.compressedLz4)
+	} else {
+		lr := io.LimitedReader{
+			R: bytes.NewBuffer(data.compressedLz4),
+		}
+		lr.N = int64(len(data.compressedLz4))
+		var in bytes.Buffer
+		testDecompress(t, c, &in, &lr, data.uncompressed)
+	}
+}
+
+func testCompress(t *testing.T, c *compr, dst, src *bytes.Buffer, target []byte) {
+	n, err := c.compress(dst, src)
+	if err != nil {
+		t.Fatal("error in compression", err)
+	}
+	if int(n)-9 != len(target) {
+		t.Fatal("compressed lengths don't match, expected:", int(n)-9, "got:", len(target))
+	}
+	if !bytes.Equal(dst.Bytes()[9:], target) {
+		t.Fatal("wrong data compression")
+	}
+}
+
+func testDecompress(t *testing.T, c *compr, dst *bytes.Buffer, src *io.LimitedReader, target []byte) {
+	n, err := c.decompress(dst, src)
+	if err != nil {
+		t.Fatal("error in decompression", err)
+	}
+	if int(n) != len(target)-9 {
+		t.Fatal("decompressed lengths don't match, expected:", int(n)-9, "got:", len(target)-9)
+	}
+	if !bytes.Equal(dst.Bytes(), target[9:]) {
+		t.Fatal("wrong data decompression")
+	}
+}


### PR DESCRIPTION
- ConnReader can now decompress frame body on recv()
- Added support for snappy and lz4

Fixes #106 