### PR TITLE
cluster: replaced btree with sorted cyclic slice

### DIFF
--- a/transport/node.go
+++ b/transport/node.go
@@ -45,3 +45,9 @@ type RingEntry struct {
 func (r RingEntry) Less(i RingEntry) bool {
 	return r.token < i.token
 }
+
+type Ring []RingEntry
+
+func (r Ring) Less(i, j int) bool { return r[i].token < r[j].token }
+func (r Ring) Len() int           { return len(r) }
+func (r Ring) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }

--- a/transport/policy_test.go
+++ b/transport/policy_test.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"testing"
 
-	"github.com/google/btree"
 	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
@@ -147,16 +146,16 @@ func mockTopologyTokenAwareSimpleStrategy() *topology {
 		{hostID: frame.UUID{2}, addr: "2", datacenter: "waw"},
 		{hostID: frame.UUID{3}, addr: "3", datacenter: "waw"},
 	}
-	ring := btree.New[RingEntry](BTreeDegree)
-
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[1], token: 50})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[0], token: 100})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[1], token: 150})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[2], token: 200})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[0], token: 250})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[1], token: 300})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[2], token: 400})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[0], token: 500})
+	ring := []RingEntry{
+		{node: dummyNodes[1], token: 50},
+		{node: dummyNodes[0], token: 100},
+		{node: dummyNodes[1], token: 150},
+		{node: dummyNodes[2], token: 200},
+		{node: dummyNodes[0], token: 250},
+		{node: dummyNodes[1], token: 300},
+		{node: dummyNodes[2], token: 400},
+		{node: dummyNodes[0], token: 500},
+	}
 
 	ks := ksMap{
 		"rf2": {strategy: strategy{class: simpleStrategy, rf: 2}},
@@ -166,8 +165,8 @@ func mockTopologyTokenAwareSimpleStrategy() *topology {
 	return &topology{
 		nodes:     dummyNodes,
 		ring:      ring,
-		trie:      trieRoot(),
 		keyspaces: ks,
+		trie:      trieRoot(),
 	}
 }
 
@@ -261,17 +260,17 @@ func mockTopologyTokenAwareNetworkStrategy() *topology {
 		{addr: "8", datacenter: "her", rack: "r4"},
 	}
 	dcs := dcRacksMap{"waw": 2, "her": 2}
-	ring := btree.New[RingEntry](BTreeDegree)
-
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[0], token: 50})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[4], token: 100})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[1], token: 150})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[0], token: 200})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[5], token: 250})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[3], token: 300})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[7], token: 400})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[6], token: 500})
-	ring.ReplaceOrInsert(RingEntry{node: dummyNodes[2], token: 510})
+	ring := Ring{
+		{node: dummyNodes[0], token: 50},
+		{node: dummyNodes[4], token: 100},
+		{node: dummyNodes[1], token: 150},
+		{node: dummyNodes[0], token: 200},
+		{node: dummyNodes[5], token: 250},
+		{node: dummyNodes[3], token: 300},
+		{node: dummyNodes[7], token: 400},
+		{node: dummyNodes[6], token: 500},
+		{node: dummyNodes[2], token: 510},
+	}
 
 	ks := ksMap{
 		"waw/her": {strategy: strategy{class: networkTopologyStrategy, dcRF: dcRFMap{"waw": 2, "her": 3}}},
@@ -281,8 +280,8 @@ func mockTopologyTokenAwareNetworkStrategy() *topology {
 		dcRacks:   dcs,
 		nodes:     dummyNodes,
 		ring:      ring,
-		trie:      trieRoot(),
 		keyspaces: ks,
+		trie:      trieRoot(),
 	}
 }
 


### PR DESCRIPTION
This pull request replaces BTree with a sorted slice recalculated on topology refresh, replicas are found using binary search. This removes function allocations regarding BTree filter functions.
It also brings back node duplicate check in SimpleStrategy as a single node can appear multiple times in a row on the token ring, example:
```
3 node cluster, keyspace with RF=2
nodetool ring testks output:
Datacenter: DC1
==========
Address     Rack        Status State   Load            Owns                Token                                       
                                                                           9206783188564719566   
...
172.18.0.2  Rack1       Up     Normal  238.6 KB        66.66%              8015852181688326448                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8048433568933139078                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8076871832946220331                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8077023708473274203                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8080725086566772156                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8107281339165255604                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8129220057764417280                         
172.18.0.3  Rack1       Up     Normal  240.9 KB        66.86%              8144347074578778593                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8159046755982979724                         
172.18.0.4  Rack1       Up     Normal  234.83 KB       66.48%              8162125543630113023                         
172.18.0.2  Rack1       Up     Normal  238.6 KB        66.66%              8171279328736593711                         
172.18.0.2  Rack1       Up     Normal  238.6 KB        66.66%              8193214119557426850
...

This breaks #247 pre-processing, hopefully I'll be able to adapt its changes without reworking the API completely.