### PR TITLE
transport: added preprocessed policies

### DIFF
--- a/query.go
+++ b/query.go
@@ -32,13 +32,13 @@ func (q *Query) pickConn() (*transport.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	it := q.session.policy.PlanIter(info)
+	n := q.session.policy.Node(info, 0)
 
 	var conn *transport.Conn
 	if tokenAware {
-		conn = it().Conn(token)
+		conn = n.Conn(token)
 	} else {
-		conn = it().LeastBusyConn()
+		conn = n.LeastBusyConn()
 	}
 	if conn == nil {
 		return nil, errNoConnection

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -39,7 +39,7 @@ func TestClusterIntegration(t *testing.T) {
 	}
 
 	// There is no one listening at the first address, it just checks cluster proper behavior.
-	c, err := NewCluster(DefaultConnConfig(""), []string{frame.StatusChange}, "123.123.123.123", TestHost)
+	c, err := NewCluster(DefaultConnConfig(""), NewTokenAwarePolicy(""), []string{frame.StatusChange}, "123.123.123.123", TestHost)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/trie.go
+++ b/transport/trie.go
@@ -1,15 +1,12 @@
 package transport
 
 import (
-	"sync"
-
 	"github.com/mmatczuk/scylla-go-driver/frame"
 )
 
 type trie struct {
 	next map[frame.UUID]*trie
 	path []*Node
-	mu   sync.RWMutex
 }
 
 func trieRoot() trie {
@@ -26,17 +23,13 @@ func newTrie(node *Node, parent *trie) *trie {
 }
 
 func (t *trie) Next(node *Node) *trie {
-	t.mu.RLock()
 	n, ok := t.next[node.hostID]
-	t.mu.RUnlock()
 	if ok {
 		return n
 	}
 
-	t.mu.Lock()
 	n = newTrie(node, t)
 	t.next[node.hostID] = n
-	t.mu.Unlock()
 	return n
 }
 


### PR DESCRIPTION
- removed wrapping of policies
- policy interface is now just Node(QueryInfo, n int), which returns the n-th node of the plan
- created policyInfo struct with Preprocess() method, meant to be called on topology refresh
  to allow calculating all possible query plans in advance,
  its passed to the policy inside QueryInfo for further use.