### PR TITLE
api: use contexts

### DIFF
--- a/session.go
+++ b/session.go
@@ -139,16 +139,16 @@ func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
 func (s *Session) Query(content string) Query {
 	return Query{session: s,
 		stmt: transport.Statement{Content: content, Consistency: s.cfg.DefaultConsistency},
-		exec: func(conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes) (transport.QueryResult, error) {
-			return conn.Query(stmt, pagingState)
+		exec: func(ctx context.Context, conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes) (transport.QueryResult, error) {
+			return conn.Query(ctx, stmt, pagingState)
 		},
-		asyncExec: func(conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes, handler transport.ResponseHandler) {
-			conn.AsyncQuery(stmt, pagingState, handler)
+		asyncExec: func(ctx context.Context, conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes, handler transport.ResponseHandler) {
+			conn.AsyncQuery(ctx, stmt, pagingState, handler)
 		},
 	}
 }
 
-func (s *Session) Prepare(content string) (Query, error) {
+func (s *Session) Prepare(ctx context.Context, content string) (Query, error) {
 	stmt := transport.Statement{Content: content, Consistency: frame.ALL}
 
 	// Prepare on all nodes concurrently.
@@ -160,7 +160,7 @@ func (s *Session) Prepare(content string) (Query, error) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			resStmt[idx], resErr[idx] = nodes[idx].Prepare(stmt)
+			resStmt[idx], resErr[idx] = nodes[idx].Prepare(ctx, stmt)
 		}(i)
 	}
 	wg.Wait()
@@ -171,11 +171,11 @@ func (s *Session) Prepare(content string) (Query, error) {
 			return Query{
 				session: s,
 				stmt:    resStmt[i],
-				exec: func(conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes) (transport.QueryResult, error) {
-					return conn.Execute(stmt, pagingState)
+				exec: func(ctx context.Context, conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes) (transport.QueryResult, error) {
+					return conn.Execute(ctx, stmt, pagingState)
 				},
-				asyncExec: func(conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes, handler transport.ResponseHandler) {
-					conn.AsyncExecute(stmt, pagingState, handler)
+				asyncExec: func(ctx context.Context, conn *transport.Conn, stmt transport.Statement, pagingState frame.Bytes, handler transport.ResponseHandler) {
+					conn.AsyncExecute(ctx, stmt, pagingState, handler)
 				},
 			}, nil
 		}

--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package scylla
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -114,14 +115,14 @@ type Session struct {
 	policy  transport.HostSelectionPolicy
 }
 
-func NewSession(cfg SessionConfig) (*Session, error) {
+func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
 	cfg = cfg.Clone()
 
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	cluster, err := transport.NewCluster(cfg.ConnConfig, cfg.Policy, cfg.Events, cfg.Hosts...)
+	cluster, err := transport.NewCluster(ctx, cfg.ConnConfig, cfg.Policy, cfg.Events, cfg.Hosts...)
 	if err != nil {
 		return nil, err
 	}

--- a/session_integration_bench_test.go
+++ b/session_integration_bench_test.go
@@ -3,11 +3,18 @@
 package scylla
 
 import (
+	"context"
+	"os/signal"
+	"syscall"
 	"testing"
 )
 
 func BenchmarkSessionQueryIntegration(b *testing.B) {
-	session := newTestSession(b)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
+	defer cancel()
+
+	session := newTestSession(ctx, b)
+	defer session.Close()
 
 	initStmts := []string{
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
@@ -67,7 +74,11 @@ func BenchmarkSessionQueryIntegration(b *testing.B) {
 }
 
 func BenchmarkSessionAsyncQueryIntegration(b *testing.B) {
-	session := newTestSession(b)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
+	defer cancel()
+
+	session := newTestSession(ctx, b)
+	defer session.Close()
 
 	initStmts := []string{
 		"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",

--- a/session_integration_bench_test.go
+++ b/session_integration_bench_test.go
@@ -24,17 +24,17 @@ func BenchmarkSessionQueryIntegration(b *testing.B) {
 
 	for _, stmt := range initStmts {
 		q := session.Query(stmt)
-		if _, err := q.Exec(); err != nil {
+		if _, err := q.Exec(ctx); err != nil {
 			b.Fatal(err)
 		}
 	}
 
-	insertQuery, err := session.Prepare(insertStmt)
+	insertQuery, err := session.Prepare(ctx, insertStmt)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	selectQuery, err := session.Prepare(selectStmt)
+	selectQuery, err := session.Prepare(ctx, selectStmt)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func BenchmarkSessionQueryIntegration(b *testing.B) {
 	b.ResetTimer()
 	for i := int64(0); i < int64(b.N); i++ {
 		insertQuery.BindInt64(0, i).BindInt64(1, 2*i).BindInt64(2, 3*i)
-		_, err := insertQuery.Exec()
+		_, err := insertQuery.Exec(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -50,7 +50,7 @@ func BenchmarkSessionQueryIntegration(b *testing.B) {
 
 	for i := int64(0); i < int64(b.N); i++ {
 		selectQuery.BindInt64(0, i)
-		res, err := selectQuery.Exec()
+		res, err := selectQuery.Exec(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -88,17 +88,17 @@ func BenchmarkSessionAsyncQueryIntegration(b *testing.B) {
 
 	for _, stmt := range initStmts {
 		q := session.Query(stmt)
-		if _, err := q.Exec(); err != nil {
+		if _, err := q.Exec(ctx); err != nil {
 			b.Fatal(err)
 		}
 	}
 
-	insertQuery, err := session.Prepare(insertStmt)
+	insertQuery, err := session.Prepare(ctx, insertStmt)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	selectQuery, err := session.Prepare(selectStmt)
+	selectQuery, err := session.Prepare(ctx, selectStmt)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func BenchmarkSessionAsyncQueryIntegration(b *testing.B) {
 	b.ResetTimer()
 	for i := int64(0); i < int64(b.N); i++ {
 		insertQuery.BindInt64(0, i).BindInt64(1, 2*i).BindInt64(2, 3*i)
-		insertQuery.AsyncExec()
+		insertQuery.AsyncExec(ctx)
 	}
 
 	for i := int64(0); i < int64(b.N); i++ {
@@ -117,7 +117,7 @@ func BenchmarkSessionAsyncQueryIntegration(b *testing.B) {
 
 	for i := int64(0); i < int64(b.N); i++ {
 		selectQuery.BindInt64(0, i)
-		selectQuery.AsyncExec()
+		selectQuery.AsyncExec(ctx)
 	}
 
 	for i := int64(0); i < int64(b.N); i++ {

--- a/transport/cluster.go
+++ b/transport/cluster.go
@@ -165,7 +165,7 @@ func (c *Cluster) NewControl(ctx context.Context) (*Conn, error) {
 	for addr := range c.knownHosts {
 		conn, err := OpenConn(ctx, addr, nil, c.cfg)
 		if err == nil {
-			if err := conn.RegisterEventHandler(c.handleEvent, c.handledEvents...); err == nil {
+			if err := conn.RegisterEventHandler(ctx, c.handleEvent, c.handledEvents...); err == nil {
 				return conn, nil
 			} else {
 				errs = append(errs, fmt.Sprintf("%s failed to register for events: %s", conn, err))
@@ -292,12 +292,12 @@ const (
 )
 
 func (c *Cluster) getAllNodesInfo(ctx context.Context) ([]frame.Row, error) {
-	peerRes, err := c.control.Query(peerQuery, nil)
+	peerRes, err := c.control.Query(ctx, peerQuery, nil)
 	if err != nil {
 		return nil, fmt.Errorf("discover peer topology: %w", err)
 	}
 
-	localRes, err := c.control.Query(localQuery, nil)
+	localRes, err := c.control.Query(ctx, localQuery, nil)
 	if err != nil {
 		return nil, fmt.Errorf("discover local topology: %w", err)
 	}
@@ -345,7 +345,7 @@ func (c *Cluster) parseNodeFromRow(r frame.Row) (*Node, error) {
 }
 
 func (c *Cluster) updateKeyspace(ctx context.Context) (ksMap, error) {
-	rows, err := c.control.Query(keyspaceQuery, nil)
+	rows, err := c.control.Query(ctx, keyspaceQuery, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -3,7 +3,10 @@
 package transport
 
 import (
+	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 
@@ -33,13 +36,16 @@ func compareNodes(c *Cluster, addr string, expected *Node) error {
 }
 
 func TestClusterIntegration(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
+	defer cancel()
+
 	addr := frame.Inet{
 		IP:   []byte{192, 168, 100, 100},
 		Port: 9042,
 	}
 
 	// There is no one listening at the first address, it just checks cluster proper behavior.
-	c, err := NewCluster(DefaultConnConfig(""), NewTokenAwarePolicy(""), []string{frame.StatusChange}, "123.123.123.123", TestHost)
+	c, err := NewCluster(ctx, DefaultConnConfig(""), NewTokenAwarePolicy(""), []string{frame.StatusChange}, "123.123.123.123", TestHost)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/compress.go
+++ b/transport/compress.go
@@ -2,8 +2,10 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/klauspost/compress/s2"
@@ -28,12 +30,15 @@ type compr struct {
 	c lz4.Compressor
 }
 
-func (c *compr) compress(dst io.Writer, src *bytes.Buffer) (written int64, err error) {
+func (c *compr) compress(ctx context.Context, dst io.Writer, src *bytes.Buffer) (written int64, err error) {
 	c.buf = *src
 	buf := c.buf.Bytes()
 	read := len(c.buf.Bytes())
 
 	if read <= 9 {
+		if err := ctx.Err(); err != nil {
+			return 0, fmt.Errorf("request aborted: %w", err)
+		}
 		nr, err := dst.Write(buf[:read])
 		return int64(nr), err
 	}
@@ -43,6 +48,10 @@ func (c *compr) compress(dst io.Writer, src *bytes.Buffer) (written int64, err e
 	var n int
 	if n, err = c.codec(read); err != nil {
 		return 0, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return 0, fmt.Errorf("request aborted: %w", err)
 	}
 
 	nrh, erh := dst.Write(c.header)

--- a/transport/compress_test.go
+++ b/transport/compress_test.go
@@ -2,9 +2,12 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"math/rand"
+	"os/signal"
+	"syscall"
 	"testing"
 
 	"github.com/klauspost/compress/s2"
@@ -132,7 +135,10 @@ func testLz4(t *testing.T, c *compr, compress bool, data *comprData) {
 }
 
 func testCompress(t *testing.T, c *compr, dst, src *bytes.Buffer, target []byte) {
-	n, err := c.compress(dst, src)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
+	defer cancel()
+
+	n, err := c.compress(ctx, dst, src)
 	if err != nil {
 		t.Fatal("error in compression", err)
 	}

--- a/transport/compress_test.go
+++ b/transport/compress_test.go
@@ -138,7 +138,7 @@ func testCompress(t *testing.T, c *compr, dst, src *bytes.Buffer, target []byte)
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
 	defer cancel()
 
-	n, err := c.compress(ctx, dst, src)
+	n, err := c.compress(ctx, ctx, dst, src)
 	if err != nil {
 		t.Fatal("error in compression", err)
 	}

--- a/transport/node.go
+++ b/transport/node.go
@@ -1,6 +1,8 @@
 package transport
 
 import (
+	"context"
+
 	"github.com/scylladb/scylla-go-driver/frame"
 	"go.uber.org/atomic"
 )
@@ -37,8 +39,8 @@ func (n *Node) Conn(token Token) *Conn {
 	return n.pool.Conn(token)
 }
 
-func (n *Node) Prepare(s Statement) (Statement, error) {
-	return n.LeastBusyConn().Prepare(s)
+func (n *Node) Prepare(ctx context.Context, s Statement) (Statement, error) {
+	return n.LeastBusyConn().Prepare(ctx, s)
 }
 
 type RingEntry struct {

--- a/transport/pool.go
+++ b/transport/pool.go
@@ -143,7 +143,7 @@ func (r *PoolRefiller) init(ctx context.Context, host string) error {
 		return err
 	}
 
-	s, err := conn.Supported()
+	s, err := conn.Supported(ctx)
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("supported: %w", err)


### PR DESCRIPTION
This PR changes NewSession, Session.Prepare, Query.Execute, Query.AsyncExecute to take context.Context as an argument.
Context passed to NewSession forces it to close on context cancellation, this is done by:
- checking ctx.Done() in cluster.loop and closing the cluster if ctx is cancelled
- checking if context is cancelled in OpenConn, preventing dialing after context cancellation.
- preventing topology refresh if context is cancelled, and during refresh in calls to openConnPool preventing opening new pools.

NewSession's context also stops requests from being sent to server in connWriter.send after cancellation,
contexts passed to Session.Prepare, Query.Execute, Query.AsyncExecute provide the same behaviour.
Context's cancellation is also checked right before allocating requests StreamID.

Requests that were sent but didn't reach the driver before context cancellation are met with an error response mentioning context cancellation, I'm not sure if this is right or if there should be a bit of additional time to receive the response, as the request may have been sent near context deadline leaving no room for receiving its response.

Also changed OpenConn to use DialContext and HandshakeContext

@martin-sucha @zimnx please let me know if this is the desired behavior, or if I missed something crucial