### PR TITLE
session: prepare now prepares on all nodes

### DIFF
--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -266,6 +266,8 @@ func makeCertificatesFromFiles(t *testing.T, certPath, keyPath string) []tls.Cer
 }
 
 func TestTLSIntegration(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	testCases := []struct {
 		name      string
 		tlsConfig *tls.Config
@@ -308,6 +310,7 @@ func TestTLSIntegration(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer session.Close()
 
 			stmts := []string{
 				"CREATE KEYSPACE IF NOT EXISTS mykeyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",

--- a/transport/node.go
+++ b/transport/node.go
@@ -37,6 +37,10 @@ func (n *Node) Conn(token Token) *Conn {
 	return n.pool.Conn(token)
 }
 
+func (n *Node) Prepare(s Statement) (Statement, error) {
+	return n.LeastBusyConn().Prepare(s)
+}
+
 type RingEntry struct {
 	node           *Node
 	token          Token

--- a/transport/policy.go
+++ b/transport/policy.go
@@ -86,7 +86,7 @@ func (pi *policyInfo) Preprocess(t *topology, ks keyspace) {
 }
 
 func (pi *policyInfo) preprocessSimpleStrategy(t *topology, stg strategy) {
-	pi.localNodes = t.nodes
+	pi.localNodes = t.Nodes
 	sort.Sort(pi.ring)
 	trie := trieRoot()
 	for i := range pi.ring {
@@ -122,14 +122,14 @@ func (pi *policyInfo) preprocessSimpleStrategy(t *topology, stg strategy) {
 }
 
 func (pi *policyInfo) preprocessRoundRobinStrategy(t *topology) {
-	pi.localNodes = t.nodes
+	pi.localNodes = t.Nodes
 	pi.remoteNodes = nil
 }
 
 func (pi *policyInfo) preprocessDCAwareRoundRobinStrategy(t *topology) {
 	pi.localNodes = make([]*Node, 0)
 	pi.remoteNodes = make([]*Node, 0)
-	for _, v := range t.nodes {
+	for _, v := range t.Nodes {
 		if v.datacenter == t.localDC {
 			pi.localNodes = append(pi.localNodes, v)
 		} else {

--- a/transport/policy_test.go
+++ b/transport/policy_test.go
@@ -20,7 +20,7 @@ func mockTopologyRoundRobin() *topology {
 	}
 
 	return &topology{
-		nodes: dummyNodes,
+		Nodes: dummyNodes,
 	}
 }
 
@@ -173,7 +173,7 @@ func mockTopologyTokenAwareSimpleStrategy() *topology {
 	}
 
 	return &topology{
-		nodes: dummyNodes,
+		Nodes: dummyNodes,
 		policyInfo: policyInfo{
 			ring: ring,
 		},
@@ -288,7 +288,7 @@ func mockTopologyTokenAwareDCAwareStrategy() *topology {
 
 	return &topology{
 		dcRacks:    dcs,
-		nodes:      dummyNodes,
+		Nodes:      dummyNodes,
 		policyInfo: policyInfo{ring: ring},
 		keyspaces:  ks,
 	}


### PR DESCRIPTION
Prepare now prepares on all nodes, once per node, as sources suggest:
https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L738-L740
https://github.com/scylladb/scylladb/blob/4d24097b4b86d484159c011f46b9e43268d342d1/transport/server.cc#L941-L950

Also made the driver fallback from token aware policy to round robin
if both session keyspace and query keyspace are unspecified, this is a temporary fix until #257 is resolved.
