### PR TITLE
query: use retry policy

### DIFF
--- a/frame/response/error.go
+++ b/frame/response/error.go
@@ -19,11 +19,11 @@ type CodedError interface {
 }
 
 func (e ScyllaError) Error() string {
-	return fmt.Sprintf("[Scylla error code=%x message=%q]", e.Code, e.Message)
+	return fmt.Sprintf("[Scylla error code=%#x message=%q]", e.Code, e.Message)
 }
 
 func (e ScyllaError) String() string {
-	return fmt.Sprintf("[Scylla error code=%x message=%q]", e.Code, e.Message)
+	return fmt.Sprintf("[Scylla error code=%#x message=%q]", e.Code, e.Message)
 }
 
 func (e ScyllaError) ErrorCode() frame.ErrorCode {

--- a/query.go
+++ b/query.go
@@ -18,7 +18,12 @@ type Query struct {
 }
 
 func (q *Query) Exec(ctx context.Context) (Result, error) {
-	conn, err := q.pickConn()
+	info, err := q.info()
+	if err != nil {
+		return Result{}, err
+	}
+
+	conn, err := q.pickConn(info)
 	if err != nil {
 		return Result{}, err
 	}
@@ -31,20 +36,10 @@ func (q *Query) Exec(ctx context.Context) (Result, error) {
 	return Result(res), q.session.handleAutoAwaitSchemaAgreement(ctx, q.stmt.Content, &res)
 }
 
-func (q *Query) pickConn() (*transport.Conn, error) {
-	token, tokenAware := q.token()
-	info, err := q.info(token, tokenAware)
-	if err != nil {
-		return nil, err
-	}
-	n := q.session.cfg.HostSelectionPolicy.Node(info, 0)
+func (q *Query) pickConn(qi transport.QueryInfo) (*transport.Conn, error) {
+	n := q.session.cfg.HostSelectionPolicy.Node(qi, 0)
 
-	var conn *transport.Conn
-	if tokenAware {
-		conn = n.Conn(token)
-	} else {
-		conn = n.LeastBusyConn()
-	}
+	conn := n.Conn(qi)
 	if conn == nil {
 		return nil, errNoConnection
 	}
@@ -54,8 +49,12 @@ func (q *Query) pickConn() (*transport.Conn, error) {
 
 func (q *Query) AsyncExec(ctx context.Context) {
 	stmt := q.stmt.Clone()
+	info, err := q.info()
+	if err != nil {
+		q.res = append(q.res, transport.MakeResponseHandlerWithError(err))
+	}
 
-	conn, err := q.pickConn()
+	conn, err := q.pickConn(info)
 	if err != nil {
 		q.res = append(q.res, transport.MakeResponseHandlerWithError(err))
 		return
@@ -106,7 +105,8 @@ func (q *Query) token() (transport.Token, bool) {
 	return transport.MurmurToken(q.buf.Bytes()), true
 }
 
-func (q *Query) info(token transport.Token, tokenAware bool) (transport.QueryInfo, error) {
+func (q *Query) info() (transport.QueryInfo, error) {
+	token, tokenAware := q.token()
 	if tokenAware {
 		// TODO: Will the driver support using different keyspaces than default?
 		info, err := q.session.cluster.NewTokenAwareQueryInfo(token, "")
@@ -160,7 +160,13 @@ func (q *Query) Iter(ctx context.Context) Iter {
 		errCh:     make(chan error, 1),
 	}
 
-	conn, err := q.pickConn()
+	info, err := q.info()
+	if err != nil {
+		it.errCh <- err
+		return it
+	}
+
+	conn, err := q.pickConn(info)
 	if err != nil {
 		it.errCh <- err
 		return it

--- a/query.go
+++ b/query.go
@@ -37,7 +37,7 @@ func (q *Query) pickConn() (*transport.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	n := q.session.policy.Node(info, 0)
+	n := q.session.cfg.HostSelectionPolicy.Node(info, 0)
 
 	var conn *transport.Conn
 	if tokenAware {

--- a/query.go
+++ b/query.go
@@ -151,6 +151,14 @@ func (q *Query) Compression() bool {
 	return q.stmt.Compression
 }
 
+func (q *Query) SetIdempotent(v bool) {
+	q.stmt.Idempotent = v
+}
+
+func (q *Query) Idempotent() bool {
+	return q.stmt.Idempotent
+}
+
 type Result transport.QueryResult
 
 func (q *Query) Iter(ctx context.Context) Iter {

--- a/session.go
+++ b/session.go
@@ -67,9 +67,9 @@ var (
 )
 
 type SessionConfig struct {
-	Hosts  []string
-	Events []EventType
-	Policy transport.HostSelectionPolicy
+	Hosts               []string
+	Events              []EventType
+	HostSelectionPolicy transport.HostSelectionPolicy
 
 	SchemaAgreementInterval time.Duration
 	// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
@@ -82,10 +82,10 @@ type SessionConfig struct {
 func DefaultSessionConfig(keyspace string, hosts ...string) SessionConfig {
 	return SessionConfig{
 		Hosts:                           hosts,
-		Policy:                          transport.NewTokenAwarePolicy(""),
-		ConnConfig:                      transport.DefaultConnConfig(keyspace),
+		HostSelectionPolicy:             transport.NewTokenAwarePolicy(""),
 		SchemaAgreementInterval:         200 * time.Millisecond,
 		AutoAwaitSchemaAgreementTimeout: 60 * time.Second,
+		ConnConfig:                      transport.DefaultConnConfig(keyspace),
 	}
 }
 
@@ -121,7 +121,6 @@ func (cfg *SessionConfig) Validate() error {
 type Session struct {
 	cfg     SessionConfig
 	cluster *transport.Cluster
-	policy  transport.HostSelectionPolicy
 }
 
 func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
@@ -131,7 +130,7 @@ func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
 		return nil, err
 	}
 
-	cluster, err := transport.NewCluster(ctx, cfg.ConnConfig, cfg.Policy, cfg.Events, cfg.Hosts...)
+	cluster, err := transport.NewCluster(ctx, cfg.ConnConfig, cfg.HostSelectionPolicy, cfg.Events, cfg.Hosts...)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +138,6 @@ func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
 	s := &Session{
 		cfg:     cfg,
 		cluster: cluster,
-		policy:  cfg.Policy,
 	}
 
 	return s, nil

--- a/session.go
+++ b/session.go
@@ -70,6 +70,7 @@ type SessionConfig struct {
 	Hosts               []string
 	Events              []EventType
 	HostSelectionPolicy transport.HostSelectionPolicy
+	RetryPolicy         transport.RetryPolicy
 
 	SchemaAgreementInterval time.Duration
 	// Controls the timeout for the automatic wait for schema agreement after sending a schema-altering statement.
@@ -83,6 +84,7 @@ func DefaultSessionConfig(keyspace string, hosts ...string) SessionConfig {
 	return SessionConfig{
 		Hosts:                           hosts,
 		HostSelectionPolicy:             transport.NewTokenAwarePolicy(""),
+		RetryPolicy:                     transport.NewDefaultRetryPolicy(),
 		SchemaAgreementInterval:         200 * time.Millisecond,
 		AutoAwaitSchemaAgreementTimeout: 60 * time.Second,
 		ConnConfig:                      transport.DefaultConnConfig(keyspace),

--- a/transport/conn.go
+++ b/transport/conn.go
@@ -808,6 +808,10 @@ func (c *Conn) String() string {
 	return fmt.Sprintf("[addr=%s shard=%d]", c.conn.RemoteAddr(), c.event.Shard)
 }
 
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
 // withPort appends new port only if addr does not contain any.
 func withPort(addr, newPort string) string {
 	host, oldPort, err := net.SplitHostPort(addr)

--- a/transport/node.go
+++ b/transport/node.go
@@ -35,9 +35,12 @@ func (n *Node) setStatus(v bool) {
 func (n *Node) LeastBusyConn() *Conn {
 	return n.pool.LeastBusyConn()
 }
+func (n *Node) Conn(qi QueryInfo) *Conn {
+	if qi.tokenAware {
+		return n.pool.Conn(qi.token)
+	}
 
-func (n *Node) Conn(token Token) *Conn {
-	return n.pool.Conn(token)
+	return n.LeastBusyConn()
 }
 
 func (n *Node) Prepare(ctx context.Context, s Statement) (Statement, error) {

--- a/transport/query.go
+++ b/transport/query.go
@@ -17,6 +17,7 @@ type Statement struct {
 	SerialConsistency frame.Consistency
 	Tracing           bool
 	Compression       bool
+	Idempotent        bool
 	Metadata          *frame.ResultMetadata
 }
 


### PR DESCRIPTION
The goal of this PR is to make normal and paged queries use the retry policy implented in #225.

RetryDecider implemented in #225 provides a Decide() method that for a error response will return a decision from list:
- DontRetry
- RetrySameNode
- RetryNextNode

In this PR I changed query.Exec() and query.Iter() to use this retry decider to iterate over the node plan generated by
the HostSelectionPolicy. 

The goal of the integration test implemented in this PR is to check if the actions performed by the driver match the Retry Policy decisions, and if using the Default Retry Policy produces the right amount of retries.

In the case of normal queries, a RetryDecider is allocated after the first try fails, avoiding unnecessary allocation in most cases.
In paged queries I added the needed fields to iterWorker, and reused the RetryDecider by calling it's Reset() method.

In case of AsyncQuery/Exec it's unclear how it should be done, as it would either require handling retries on the side of connection / cluster which doesn't make sense to me. Other possibility would be to do retries in Fetch() after reading the result, but here we would need to somehow keep the connection/node that the request was sent to to do a same node retry, etc. So for now I am leaving it as it is.
