### PR TITLE
Replace mmatczuk with scylladb in module path

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,6 @@
 package scylla
 
-import "github.com/mmatczuk/scylla-go-driver/frame"
+import "github.com/scylladb/scylla-go-driver/frame"
 
 // This file is identical to errors.go located in scylla pkg.
 // Error codes are necessary in frame pkg for parsing responses,

--- a/experiments/cmd/benchtab/main.go
+++ b/experiments/cmd/benchtab/main.go
@@ -6,8 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mmatczuk/scylla-go-driver"
 	"github.com/pkg/profile"
+	"github.com/scylladb/scylla-go-driver"
 )
 
 const insertStmt = "INSERT INTO benchtab (pk, v1, v2) VALUES(?, ?, ?)"

--- a/experiments/cqlasmap_bench_test.go
+++ b/experiments/cqlasmap_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func CqlAsMap[K comparable, V any](c frame.CqlValue) (map[K]V, error) {

--- a/frame/request/authresponse.go
+++ b/frame/request/authresponse.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*AuthResponse)(nil)

--- a/frame/request/authresponse_fuzz_test.go
+++ b/frame/request/authresponse_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzAuthResponse(f *testing.F) {

--- a/frame/request/authresponse_test.go
+++ b/frame/request/authresponse_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/batch.go
+++ b/frame/request/batch.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 const (

--- a/frame/request/batch_fuzz_test.go
+++ b/frame/request/batch_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzBatch(f *testing.F) {

--- a/frame/request/batch_test.go
+++ b/frame/request/batch_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/execute.go
+++ b/frame/request/execute.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Execute)(nil)

--- a/frame/request/execute_fuzz_test.go
+++ b/frame/request/execute_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzExecute(f *testing.F) {

--- a/frame/request/execute_test.go
+++ b/frame/request/execute_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/options.go
+++ b/frame/request/options.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Options)(nil)

--- a/frame/request/prepare.go
+++ b/frame/request/prepare.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Prepare)(nil)

--- a/frame/request/prepare_fuzz_test.go
+++ b/frame/request/prepare_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzPrepare(f *testing.F) {

--- a/frame/request/prepare_test.go
+++ b/frame/request/prepare_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/query.go
+++ b/frame/request/query.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Query)(nil)

--- a/frame/request/query_fuzz_test.go
+++ b/frame/request/query_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzQuery(f *testing.F) {

--- a/frame/request/query_test.go
+++ b/frame/request/query_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/register.go
+++ b/frame/request/register.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Register)(nil)

--- a/frame/request/register_fuzz_test.go
+++ b/frame/request/register_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzRegister(f *testing.F) {

--- a/frame/request/register_test.go
+++ b/frame/request/register_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/request/startup.go
+++ b/frame/request/startup.go
@@ -1,7 +1,7 @@
 package request
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var _ frame.Request = (*Startup)(nil)

--- a/frame/request/startup_fuzz_test.go
+++ b/frame/request/startup_fuzz_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func FuzzStartup(f *testing.F) {

--- a/frame/request/startup_test.go
+++ b/frame/request/startup_test.go
@@ -3,7 +3,7 @@ package request
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authchallenge.go
+++ b/frame/response/authchallenge.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // AuthChallenge spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L802

--- a/frame/response/authchallenge_fuzz_test.go
+++ b/frame/response/authchallenge_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var dummyAC *AuthChallenge

--- a/frame/response/authchallenge_test.go
+++ b/frame/response/authchallenge_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authenticate.go
+++ b/frame/response/authenticate.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Authenticate spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L517

--- a/frame/response/authenticate_fuzz_test.go
+++ b/frame/response/authenticate_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var dummyA *Authenticate

--- a/frame/response/authenticate_test.go
+++ b/frame/response/authenticate_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/authsuccess.go
+++ b/frame/response/authsuccess.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // AuthSuccess spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L814

--- a/frame/response/authsuccess_fuzz_test.go
+++ b/frame/response/authsuccess_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var dummyAS *AuthSuccess

--- a/frame/response/authsuccess_test.go
+++ b/frame/response/authsuccess_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/error.go
+++ b/frame/response/error.go
@@ -3,7 +3,7 @@ package response
 import (
 	"fmt"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // ScyllaError is embedded in all error frames.

--- a/frame/response/error_fuzz_test.go
+++ b/frame/response/error_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var (

--- a/frame/response/error_test.go
+++ b/frame/response/error_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/event.go
+++ b/frame/response/event.go
@@ -3,7 +3,7 @@ package response
 import (
 	"log"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Event spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L754

--- a/frame/response/event_fuzz_test.go
+++ b/frame/response/event_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var (

--- a/frame/response/event_test.go
+++ b/frame/response/event_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/ready.go
+++ b/frame/response/ready.go
@@ -1,7 +1,7 @@
 package response
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Ready spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L507

--- a/frame/response/result.go
+++ b/frame/response/result.go
@@ -3,7 +3,7 @@ package response
 import (
 	"log"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Result spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L546

--- a/frame/response/result_fuzz_test.go
+++ b/frame/response/result_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var (

--- a/frame/response/result_test.go
+++ b/frame/response/result_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/frame/response/supported.go
+++ b/frame/response/supported.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Supported spec: https://github.com/apache/cassandra/blob/adcff3f630c0d07d1ba33bf23fcb11a6db1b9af1/doc/native_protocol_v4.spec#L537

--- a/frame/response/supported_fuzz_test.go
+++ b/frame/response/supported_fuzz_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var dummyS *Supported

--- a/frame/response/supported_test.go
+++ b/frame/response/supported_test.go
@@ -3,7 +3,7 @@ package response
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mmatczuk/scylla-go-driver
+module github.com/scylladb/scylla-go-driver
 
 go 1.18
 

--- a/query.go
+++ b/query.go
@@ -3,8 +3,8 @@ package scylla
 import (
 	"fmt"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	"github.com/mmatczuk/scylla-go-driver/transport"
+	"github.com/scylladb/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/transport"
 )
 
 type Query struct {

--- a/session.go
+++ b/session.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"sync"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	"github.com/mmatczuk/scylla-go-driver/transport"
+	"github.com/scylladb/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/transport"
 )
 
 // TODO: Add retry policy.

--- a/transport/cluster.go
+++ b/transport/cluster.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 )
 
 const awaitingChanges = 100 * time.Millisecond

--- a/transport/compress.go
+++ b/transport/compress.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/klauspost/compress/s2"
-	"github.com/mmatczuk/scylla-go-driver/frame"
 	"github.com/pierrec/lz4/v4"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 var (

--- a/transport/compress_test.go
+++ b/transport/compress_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/s2"
-	"github.com/mmatczuk/scylla-go-driver/frame"
 	"github.com/pierrec/lz4/v4"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 type comprData struct {

--- a/transport/conn.go
+++ b/transport/conn.go
@@ -15,9 +15,9 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/request"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/request"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/conn_integration_test.go
+++ b/transport/conn_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/transport/error.go
+++ b/transport/error.go
@@ -3,8 +3,8 @@ package transport
 import (
 	"fmt"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 )
 
 // responseAsError returns either IoError or some error defined in response.error.

--- a/transport/node.go
+++ b/transport/node.go
@@ -1,7 +1,7 @@
 package transport
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 	"go.uber.org/atomic"
 )
 

--- a/transport/policy_test.go
+++ b/transport/policy_test.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 // Round-Robin tests can't be run in parallel because

--- a/transport/pool.go
+++ b/transport/pool.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 
 	"go.uber.org/atomic"
 )

--- a/transport/query.go
+++ b/transport/query.go
@@ -1,9 +1,9 @@
 package transport
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/request"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/request"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 )
 
 type Statement struct {

--- a/transport/retry.go
+++ b/transport/retry.go
@@ -1,8 +1,8 @@
 package transport
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 )
 
 type RetryInfo struct {

--- a/transport/retry_test.go
+++ b/transport/retry_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
-	. "github.com/mmatczuk/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/frame"
+	. "github.com/scylladb/scylla-go-driver/frame/response"
 )
 
 func TestDefaultRetryPolicy(t *testing.T) {

--- a/transport/routing.go
+++ b/transport/routing.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"math/rand"
 
-	"github.com/mmatczuk/scylla-go-driver/transport/murmur"
+	"github.com/scylladb/scylla-go-driver/transport/murmur"
 )
 
 const (

--- a/transport/stream.go
+++ b/transport/stream.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"math/bits"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 const (

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"testing"
 
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 func TestStreamIDAllocator(t *testing.T) {

--- a/transport/trie.go
+++ b/transport/trie.go
@@ -1,7 +1,7 @@
 package transport
 
 import (
-	"github.com/mmatczuk/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/frame"
 )
 
 type trie struct {


### PR DESCRIPTION
The repository was moved from

https://github.com/mmatczuk/scylla-go-driver

to

https://github.com/scylladb/scylla-go-driver

but the module path still contained the old name.

While it is possible to import the driver with the old import path,
using the one with scylladb will make importing the driver
a little bit more obvious.

The change might break external modules that depend on the driver
now, but I don't expect there to be many of those, since the
driver is still experimental.