### PR TITLE
Wait for schema agreement automatically

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ COMPOSE_PROJECT_NAME="scylla_go_driver"
 
 SCYLLA_IMAGE=scylladb/scylla
 SCYLLA_VERSION=5.0.0
-SCYLLA_ARGS="--smp 4 --memory 4G --authenticator PasswordAuthenticator"
+SCYLLA_ARGS="--seeds=node1,node2 --smp 4 --memory 4G --authenticator PasswordAuthenticator --api-address 0.0.0.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,9 @@
 version: "3.7"
 
 services:
-  node:
-    cpuset: "0-3"
+  node1:
     image: ${SCYLLA_IMAGE}:${SCYLLA_VERSION}
-    command: ${SCYLLA_ARGS}
-    ports:
-      - "9042:9042"
-      - "19042:19042"
-      - "9142:9142"
-      - "19142:19142"
+    command: ${SCYLLA_ARGS} --seeds 192.168.100.100 --skip-wait-for-gossip-to-settle 0
     networks:
       public:
         ipv4_address: 192.168.100.100
@@ -17,15 +11,29 @@ services:
     - type: bind
       source: ./testdata/config/scylla.yaml
       target: /etc/scylla/scylla.yaml
+    - "./testdata/tls:/etc/scylla/tls"
+  node2:
+    image: ${SCYLLA_IMAGE}:${SCYLLA_VERSION}
+    command: ${SCYLLA_ARGS} --seeds 192.168.100.100 --skip-wait-for-gossip-to-settle 0
+    networks:
+      public:
+        ipv4_address: 192.168.100.101
+    volumes:
     - type: bind
-      source: ./testdata/tls/cadb.pem
-      target: /etc/scylla/cadb.pem
+      source: ./testdata/config/scylla.yaml
+      target: /etc/scylla/scylla.yaml
+    - "./testdata/tls:/etc/scylla/tls"
+  node3:
+    image: ${SCYLLA_IMAGE}:${SCYLLA_VERSION}
+    command: ${SCYLLA_ARGS} --seeds 192.168.100.100,192.168.100.101 --skip-wait-for-gossip-to-settle 0
+    networks:
+      public:
+        ipv4_address: 192.168.100.102
+    volumes:
     - type: bind
-      source: ./testdata/tls/db.crt
-      target: /etc/scylla/db.crt
-    - type: bind
-      source: ./testdata/tls/db.key
-      target: /etc/scylla/db.key
+      source: ./testdata/config/scylla.yaml
+      target: /etc/scylla/scylla.yaml
+    - "./testdata/tls:/etc/scylla/tls"
 
 networks:
   public:

--- a/query.go
+++ b/query.go
@@ -24,7 +24,11 @@ func (q *Query) Exec(ctx context.Context) (Result, error) {
 	}
 
 	res, err := q.exec(ctx, conn, q.stmt, nil)
-	return Result(res), err
+	if err != nil {
+		return Result(res), err
+	}
+
+	return Result(res), q.session.handleAutoAwaitSchemaAgreement(ctx, q.stmt.Content, &res)
 }
 
 func (q *Query) pickConn() (*transport.Conn, error) {

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"syscall"
 	"testing"
-	"time"
 
 	"go.uber.org/goleak"
 )
@@ -377,9 +376,6 @@ func TestPrepareIntegration(t *testing.T) {
 		if _, err := q.Exec(ctx); err != nil {
 			t.Fatal(err)
 		}
-
-		// Await schema agreement, TODO: implement true schema agreement and remove this.
-		time.Sleep(time.Second)
 	}
 
 	q, err := session.Prepare(ctx, "INSERT INTO testks.doubles (pk, v) VALUES (?, ?)")
@@ -435,9 +431,6 @@ func TestContextsIntegration(t *testing.T) {
 		if _, err := q.Exec(ctx); err != nil {
 			t.Fatal(err)
 		}
-
-		// Await schema agreement, TODO: implement true schema agreement and remove this.
-		time.Sleep(time.Second)
 	}
 
 	insertQ, err := session.Prepare(ctx, "INSERT INTO contextks.t(pk) VALUES (?)")

--- a/testdata/config/scylla.yaml
+++ b/testdata/config/scylla.yaml
@@ -4,7 +4,7 @@ native_shard_aware_transport_port: 19042
 native_shard_aware_transport_port_ssl: 19142
 client_encryption_options:
   enabled: true
-  certificate: /etc/scylla/db.crt
-  keyfile: /etc/scylla/db.key
-  truststore: /etc/scylla/cadb.pem
+  certificate: /etc/scylla/tls/db.crt
+  keyfile: /etc/scylla/tls/db.key
+  truststore: /etc/scylla/tls/cadb.pem
   require_client_auth: true

--- a/transport/query.go
+++ b/transport/query.go
@@ -74,6 +74,7 @@ type QueryResult struct {
 	HasMorePages bool
 	PagingState  frame.Bytes
 	ColSpec      []frame.ColumnSpec
+	SchemaChange *SchemaChange
 }
 
 func MakeQueryResult(res frame.Response, meta *frame.ResultMetadata) (QueryResult, error) {
@@ -93,8 +94,10 @@ func MakeQueryResult(res frame.Response, meta *frame.ResultMetadata) (QueryResul
 			}
 		}
 		return ret, nil
-	case *VoidResult, *SchemaChangeResult, *SetKeyspaceResult:
+	case *VoidResult, *SetKeyspaceResult:
 		return QueryResult{}, nil
+	case *SchemaChangeResult:
+		return QueryResult{SchemaChange: &v.SchemaChange}, nil
 	default:
 		return QueryResult{}, responseAsError(res)
 	}


### PR DESCRIPTION
This PR adds the ability of checking and awaiting schema agreement by calling adequate methods on Session and Node.
Schema agreement is checked by checking if all nodes have the same schema_version in system.local table, same as in https://github.com/scylladb/scylla-rust-driver/pull/250

It also makes the driver await schema agreement automatically after queries changing schema:
Paraphrasing https://github.com/scylladb/scylla-rust-driver/pull/460
>Now, the session automatically waits for schema agreement after
>executing a statement which modifies the schema. The rationale for this
>change is that, previously, it was the user's responsibility to wait for
>schema agreement and it was easy to forget about this check.
>
>The automatic wait for schema agreement is never a bug, although it can
>slow down some programs which do a lot of schema changes in a short
>succession. Those applications can opt-out of this feature by disabling
>the feature in the configuration and can still wait for schema agreement
>manually.
>
>The session will wait for schema agreement for a configured amount of
>time, and then - if the agreement is not reached - it will return an error.

This PR also changes the docker-compose.yml to use a 3 node setup as schema agreement integration tests don't make
much sense in case of a single node cluster.