### PR TITLE
Run integration tests in Github Workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
 permissions:
   contents: read
+env:
+  SCYLLA_ARGS: "--seeds=node1,node2 --authenticator PasswordAuthenticator --api-address 0.0.0.0"
 jobs:
   sanity:
     name: Sanity check
@@ -28,6 +30,21 @@ jobs:
         with:
           version: v1.46.2
 
+      - name: Setup 3-node Scylla cluster
+        run: |
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+          docker-compose up -d
+
       - name: Run tests
         run: make test
 
+      - name: Ensure nodes are up
+        run: |
+          until docker compose exec node1 nodetool status; do sleep 1; done
+          while [[ $(docker compose exec node1 nodetool status | grep -c ^UN) != "3" ]]; do sleep 1; done
+
+      - name: Run integration tests
+        run: make docker-integration-test
+        
+      - name: Stop cluster
+        run: docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,16 @@ else
 	$(error Unsupported OS $(OS))
 endif
 
+.PHONY: docker-integration-test
+docker-integration-test: RUN=Integration
+docker-integration-test:
+	@CGO_ENABLED=0 GOOS=linux go test -v -tags integration -c -o ./integration-test.dev $(PKG)
+	@docker run --name "integration-test" \
+		--network scylla_go_driver_public \
+		-v "$(PWD)/testdata:/testdata" \
+		-v "$(PWD)/integration-test.dev:/usr/bin/integration-test:ro" \
+		-i --read-only --rm ubuntu integration-test -test.v -test.run $(RUN) $(ARGS)
+
 .PHONY: run-benchtab
 run-benchtab: CPUSET=4-5
 run-benchtab:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ else ifeq ($(OS),Darwin)
 	@CGO_ENABLED=0 GOOS=linux go test -v -tags integration -c -o ./integration-test.dev $(PKG)
 	@docker run --name "integration-test" \
 		--network scylla_go_driver_public \
+		-v "$(PWD)/testdata:/testdata" \
 		-v "$(PWD)/integration-test.dev:/usr/bin/integration-test:ro" \
 		-it --read-only --rm ubuntu integration-test -test.v -test.run $(RUN) $(ARGS)
 else


### PR DESCRIPTION
The goal of this PR is to run integration tests on the cluster described by docker-compose.yml in GH workflows.
It extends the Makefile with ability to run integration tests in docker, this is used by the modified workflow.

This PR also resolves a small bug in OpenShardConn, when context is done, instead of immediate return from the function, it would try all ports as connections wouldn't open due to context being done, bloating the integration test log with thousands of lines.