### PR TITLE
session: allow log configuration using Logger interface.

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"log"
+	"os"
+)
+
+type Logger interface {
+	Info(v ...any)
+	Infof(format string, v ...any)
+	Infoln(v ...any)
+
+	Warn(v ...any)
+	Warnf(format string, v ...any)
+	Warnln(v ...any)
+}
+
+// DefaultLogger only logs warnings and critical errors.
+type DefaultLogger struct {
+	warn *log.Logger
+}
+
+func NewDefaultLogger() *DefaultLogger {
+	res := &DefaultLogger{
+		warn: log.New(os.Stderr, "WARNING ", log.LstdFlags),
+	}
+	return res
+}
+
+func (logger *DefaultLogger) Info(v ...any)                 {}
+func (logger *DefaultLogger) Infof(format string, v ...any) {}
+func (logger *DefaultLogger) Infoln(v ...any)               {}
+
+func (logger *DefaultLogger) Warn(v ...any)                 { logger.warn.Print(v...) }
+func (logger *DefaultLogger) Warnf(format string, v ...any) { logger.warn.Printf(format, v...) }
+func (logger *DefaultLogger) Warnln(v ...any)               { logger.warn.Println(v...) }
+
+// DebugLogger logs both warnings and information about important events in driver's runtime.
+type DebugLogger struct {
+	info *log.Logger
+	warn *log.Logger
+}
+
+func NewDebugLogger() *DebugLogger {
+	res := &DebugLogger{
+		info: log.New(os.Stderr, "INFO ", log.LstdFlags),
+		warn: log.New(os.Stderr, "WARNING ", log.LstdFlags),
+	}
+	return res
+}
+
+func (logger *DebugLogger) Info(v ...any)                 { logger.info.Print(v...) }
+func (logger *DebugLogger) Infof(format string, v ...any) { logger.info.Printf(format, v...) }
+func (logger *DebugLogger) Infoln(v ...any)               { logger.info.Println(v...) }
+
+func (logger *DebugLogger) Warn(v ...any)                 { logger.warn.Print(v...) }
+func (logger *DebugLogger) Warnf(format string, v ...any) { logger.warn.Printf(format, v...) }
+func (logger *DebugLogger) Warnln(v ...any)               { logger.warn.Println(v...) }
+
+// NopLogger doesn't log anything.
+type NopLogger struct{}
+
+func (NopLogger) Info(v ...any)                 {}
+func (NopLogger) Infof(format string, v ...any) {}
+func (NopLogger) Infoln(v ...any)               {}
+
+func (NopLogger) Warn(v ...any)                 {}
+func (NopLogger) Warnf(format string, v ...any) {}
+func (NopLogger) Warnln(v ...any)               {}

--- a/session.go
+++ b/session.go
@@ -3,7 +3,6 @@ package scylla
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -271,6 +270,6 @@ func (s *Session) NewTokenAwareDCAwarePolicy(localDC string) transport.HostSelec
 }
 
 func (s *Session) Close() {
-	log.Println("session: close")
+	s.cfg.Logger.Info("session: close")
 	s.cluster.Close()
 }

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -18,13 +18,18 @@ import (
 
 	"github.com/scylladb/scylla-go-driver/frame"
 	"github.com/scylladb/scylla-go-driver/frame/response"
+	"github.com/scylladb/scylla-go-driver/log"
 	"github.com/scylladb/scylla-go-driver/transport"
 	"go.uber.org/goleak"
 )
 
 const TestHost = "192.168.100.100"
 
-var testingSessionConfig = DefaultSessionConfig("mykeyspace", TestHost)
+var testingSessionConfig = func() SessionConfig {
+	cfg := DefaultSessionConfig("mykeyspace", TestHost)
+	cfg.Logger = log.NewDebugLogger()
+	return cfg
+}()
 
 func initKeyspace(ctx context.Context, t testing.TB) {
 	t.Helper()

--- a/transport/node.go
+++ b/transport/node.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/scylladb/scylla-go-driver/frame"
 	"go.uber.org/atomic"
@@ -40,7 +39,7 @@ func (n *Node) Init(ctx context.Context, cfg ConnConfig) {
 		if err == nil {
 			n.setStatus(statusUP)
 		} else {
-			log.Printf("couldn't create a connection pool to node %v: %v;setting node status to DOWN", n, err)
+			cfg.Logger.Infof("couldn't create a connection pool to node %v: %v;setting node status to DOWN", n, err)
 			n.setStatus(statusDown)
 		}
 	}

--- a/transport/observer.go
+++ b/transport/observer.go
@@ -2,8 +2,9 @@ package transport
 
 import (
 	"fmt"
-	"log"
 	"time"
+
+	"github.com/scylladb/scylla-go-driver/log"
 )
 
 var Now = time.Now
@@ -51,18 +52,20 @@ type ConnObserver interface {
 	OnPickReplacedWithLessBusyConn(ev ConnEvent)
 }
 
-type LoggingConnObserver struct{}
+type LoggingConnObserver struct {
+	log log.Logger
+}
 
 var _ ConnObserver = LoggingConnObserver{}
 
 func (o LoggingConnObserver) OnConnect(ev ConnectEvent) {
 	if ev.Err != nil {
-		log.Printf("%s failed to open connection after %s: %s", ev, ev.Duration(), ev.Err)
+		o.log.Infof("%s failed to open connection after %s: %s", ev, ev.Duration(), ev.Err)
 	} else {
-		log.Printf("%s connected in %s", ev, ev.Duration())
+		o.log.Infof("%s connected in %s", ev, ev.Duration())
 	}
 }
 
 func (o LoggingConnObserver) OnPickReplacedWithLessBusyConn(ev ConnEvent) {
-	log.Printf("%s pick replaced with less busy conn", ev)
+	o.log.Infof("%s pick replaced with less busy conn", ev)
 }

--- a/transport/policy.go
+++ b/transport/policy.go
@@ -1,8 +1,9 @@
 package transport
 
 import (
-	"log"
 	"sort"
+
+	"github.com/scylladb/scylla-go-driver/log"
 )
 
 // HostSelectionPolicy decides which node the query should be routed to.
@@ -69,14 +70,14 @@ type policyInfo struct {
 	remoteNodes []*Node
 }
 
-func (pi *policyInfo) Preprocess(t *topology, ks keyspace) {
+func (pi *policyInfo) Preprocess(t *topology, ks keyspace, logger log.Logger) {
 	switch ks.strategy.class {
 	case simpleStrategy, localStrategy:
 		pi.preprocessSimpleStrategy(t, ks.strategy)
 	case networkTopologyStrategy:
 		pi.preprocessNetworkTopologyStrategy(t, ks.strategy)
 	default:
-		log.Println("policyInfo: unknown strategy, defaulting to round robin")
+		logger.Warnf("policyInfo: keyspace %v has unknown strategy, defaulting to round robin")
 		if t.localDC == "" {
 			pi.preprocessRoundRobinStrategy(t)
 		} else {

--- a/transport/policy_test.go
+++ b/transport/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/scylladb/scylla-go-driver/frame"
+	"github.com/scylladb/scylla-go-driver/log"
 )
 
 // Round-Robin tests can't be run in parallel because
@@ -29,9 +30,9 @@ func mockCluster(t *topology, ks, localDC string) *Cluster {
 	t.localDC = localDC
 
 	if k, ok := t.keyspaces[ks]; ok {
-		t.policyInfo.Preprocess(t, k)
+		t.policyInfo.Preprocess(t, k, log.NewDebugLogger())
 	} else {
-		t.policyInfo.Preprocess(t, keyspace{})
+		t.policyInfo.Preprocess(t, keyspace{}, log.NewDebugLogger())
 	}
 	c.setTopology(t)
 

--- a/transport/pool.go
+++ b/transport/pool.go
@@ -191,7 +191,7 @@ func (r *PoolRefiller) onConnClose(conn *Conn) {
 	select {
 	case r.pool.connClosedCh <- conn.Shard():
 	default:
-		log.Printf("conn pool: ignoring conn %s close", conn)
+		r.cfg.Logger.Infof("conn pool: ignoring conn %s close", conn)
 	}
 }
 

--- a/transport/pool_integration_test.go
+++ b/transport/pool_integration_test.go
@@ -14,7 +14,7 @@ import (
 const refillerBackoff = 500 * time.Millisecond
 
 func newTestConnPool(ctx context.Context, t *testing.T) *ConnPool {
-	p, err := NewConnPool(ctx, TestHost, DefaultConnConfig(""))
+	p, err := NewConnPool(ctx, TestHost, testingConnConfig)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR provides a Logger interface allowing to supply
a custom logger as part of (Session)ConnConfig.

It also provides three implementations of Logger:
- DefaultLogger, logging only warnings
- DebugLogger, logging everything that can be useful for debugging,
  it is used by default in tests
- NopLogger, logging nothing

Fixes #271