### PR TITLE
transport: fixed an overflow in ShardPortIterator

### DIFF
--- a/transport/routing.go
+++ b/transport/routing.go
@@ -30,14 +30,14 @@ func RandomShardPort(si ShardInfo) uint16 {
 // ShardPortIterator returns iterator for consecutive ports that are
 // mapped to a specific shard on scylla node.
 func ShardPortIterator(si ShardInfo) func() uint16 {
-	port := RandomShardPort(si)
+	port := int(RandomShardPort(si))
 
 	return func() uint16 {
-		port += si.NrShards
+		port += int(si.NrShards)
 		if port > maxPort {
-			port = (minPort+si.NrShards-1)/si.NrShards*si.NrShards + si.Shard
+			port = int((minPort+si.NrShards-1)/si.NrShards*si.NrShards + si.Shard)
 		}
-		return port
+		return uint16(port)
 	}
 }
 

--- a/transport/routing_test.go
+++ b/transport/routing_test.go
@@ -1,0 +1,27 @@
+package transport
+
+import "testing"
+
+func TestShardPortIterator(t *testing.T) {
+	t.Parallel()
+	for shards := 1; shards < 128; shards++ {
+		for shard := 0; shard < shards; shard++ {
+			si := ShardInfo{
+				Shard:    uint16(shard),
+				NrShards: uint16(shards),
+			}
+
+			it := ShardPortIterator(si)
+			finishPort := it()
+			for port := it(); port != finishPort; port = it() {
+				if port < minPort || port > maxPort {
+					t.Fatalf("port %d is not in range [%d, %d]", port, minPort, maxPort)
+				}
+
+				if int(port)%shards != shard {
+					t.Fatalf("port %d doesn't correspond to shard %d", port, shard)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
There was an overflow in ShardPortIterator, leading the driver sometimes to dial from source ports outside of range specified in routing.go by minPort and maxPort, trying dialing from reserved ports. Also this overflow can make the driver pick a source port that doesn't correspond to the queried shard.

This PR removes this overflow, and adds a test checking for correct behavior of ShardPortIterator.