### PR TITLE
transport: avoid nil pointer dereferencing

### DIFF
--- a/session.go
+++ b/session.go
@@ -56,7 +56,7 @@ var (
 		"SERIAL      Consistency = 0x0008\n" +
 		"LOCALSERIAL Consistency = 0x0009\n" +
 		"LOCALONE    Consistency = 0x000A")
-	errNoConnection = fmt.Errorf("no working connection")
+	ErrNoConnection = fmt.Errorf("no connection to execute the query on")
 )
 
 type Compression = frame.Compression

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -51,7 +51,7 @@ func TestClusterIntegration(t *testing.T) {
 	}
 
 	// Checks cluster behavior after receiving event with error.
-	c.handleEvent(response{Err: fmt.Errorf("fake error")})
+	c.handleEvent(ctx, response{Err: fmt.Errorf("fake error")})
 
 	expected := &Node{
 		addr:       TestHost,
@@ -65,12 +65,14 @@ func TestClusterIntegration(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	c.handleEvent(response{
-		Response: &StatusChange{
-			Status:  frame.Down,
-			Address: addr,
-		},
-	})
+	c.handleEvent(
+		ctx,
+		response{
+			Response: &StatusChange{
+				Status:  frame.Down,
+				Address: addr,
+			},
+		})
 	expected.setStatus(statusDown)
 
 	time.Sleep(awaitingChanges)
@@ -84,12 +86,14 @@ func TestClusterIntegration(t *testing.T) {
 		t.Fatalf("Keyspaces failed to load")
 	}
 
-	c.handleEvent(response{
-		Response: &TopologyChange{
-			Change:  frame.NewNode,
-			Address: addr,
-		},
-	})
+	c.handleEvent(
+		ctx,
+		response{
+			Response: &TopologyChange{
+				Change:  frame.NewNode,
+				Address: addr,
+			},
+		})
 
 	time.Sleep(awaitingChanges)
 	// Checks if cluster can handle (fake) topology change.

--- a/transport/cluster_integration_test.go
+++ b/transport/cluster_integration_test.go
@@ -22,8 +22,8 @@ func compareNodes(c *Cluster, addr string, expected *Node) error {
 	switch {
 	case !ok:
 		return fmt.Errorf("couldn't find node: %s in cluster's nodes", addr)
-	case got.Status() != expected.Status():
-		return fmt.Errorf("got status: %t, expected: %t", got.Status(), expected.Status())
+	case got.IsUp() != expected.IsUp():
+		return fmt.Errorf("got status: %t, expected: %t", got.IsUp(), expected.IsUp())
 	case got.addr != expected.addr:
 		return fmt.Errorf("got IP address: %s, expected: %s", got.addr, expected.addr)
 	case got.rack != expected.rack:

--- a/transport/node.go
+++ b/transport/node.go
@@ -25,7 +25,7 @@ type Node struct {
 	status     nodeStatus
 }
 
-func (n *Node) Status() bool {
+func (n *Node) IsUp() bool {
 	return n.status.Load()
 }
 

--- a/transport/node.go
+++ b/transport/node.go
@@ -54,9 +54,16 @@ func (n *Node) Close() {
 }
 
 func (n *Node) LeastBusyConn() (*Conn, error) {
+	if !n.IsUp() {
+		return nil, fmt.Errorf("node %v is down", n)
+	}
+
 	return n.pool.LeastBusyConn()
 }
 func (n *Node) Conn(qi QueryInfo) (*Conn, error) {
+	if !n.IsUp() {
+		return nil, fmt.Errorf("node %v is down", n)
+	}
 	if qi.tokenAware {
 		return n.pool.Conn(qi.token)
 	}

--- a/transport/pool_integration_test.go
+++ b/transport/pool_integration_test.go
@@ -72,21 +72,27 @@ func TestConnPoolConnIntegration(t *testing.T) {
 	defer p.Close()
 
 	t0 := MurmurToken([]byte(""))
-	if conn := p.Conn(t0); conn == nil || conn.Shard() != 0 {
+	if conn, err := p.Conn(t0); err != nil || conn.Shard() != 0 {
 		t.Fatal("invalid return of Conn")
 	}
 
 	load := uint32(math.Floor(maxStreamID/2 + 1))
-	p.Conn(t0).stats.inQueue.Store(load)
 
-	if conn := p.Conn(t0); conn == nil {
+	conn, err := p.Conn(t0)
+	if err != nil {
+		t.Fatal("invalid return of Conn")
+	}
+
+	conn.stats.inQueue.Store(load)
+
+	if conn, err := p.Conn(t0); err != nil {
 		t.Fatal("invalid return of Conn")
 	} else if conn.Shard() == 0 {
 		t.Fatalf("invalid load distribution")
 	}
 
 	t1 := MurmurToken([]byte("0")) // Very big number approx. 3 * 10^18.
-	if conn := p.Conn(t1); conn == nil {
+	if _, err := p.Conn(t1); err != nil {
 		t.Fatal("invalid return of Conn")
 	}
 }


### PR DESCRIPTION
The goal of this PR is to resolve two intertwined issues:
-  #279 
The problem here was that on initial discovery of a node, if it was down it's pool couldn't be initialized, leaving it as nil.
When a topology refresh happens, the driver was reusing the pool without checking if it actually exists.<br>
For this problem the proposed solution is to move the node's connection pool and status initialization to the Node, instead of managing it inside cluster, calling node.Init() in places where the node could have status UP to ensure we have working connections to this node.

-  #222 
This issue comes with two problems: pool being nil from reasons mentioned above, and pool returning nil connections, as the node may be down, or a shard connection is missing.<br>
The proposed solution is to indicate the connection is missing by returning an error giving context about why it's missing, especially when a node's status is DOWN, making the retry policy skip nodes which don't have a working connection available.

Motivation behind this PR is to stop the integration tests from failing on GH Actions, not fix node status handling entirely, that should be done in a separate PR resolving #293 

#222 was causing panics in TestContextIntegration when connections were closed but session didn't fully close yet, running the tests in github actions confirms that this is not the case anymore.

I also ran manual tests with steps mentioned in #279, confirming that pool is initialized properly.

Fixes: #279 
Fixes: #222 