### PR TITLE
transport: conn, abort OpenShardConn faster

### DIFF
--- a/transport/conn.go
+++ b/transport/conn.go
@@ -376,6 +376,10 @@ func OpenShardConn(ctx context.Context, addr string, si ShardInfo, cfg ConnConfi
 	it := ShardPortIterator(si)
 	maxTries := (maxPort-minPort+1)/int(si.NrShards) + 1
 	for i := 0; i < maxTries; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("aborted opening connection on shard %d: %w", si.Shard, err)
+		}
+
 		conn, err := OpenLocalPortConn(ctx, addr, it(), cfg)
 		if err != nil {
 			log.Printf("%s dial error: %s (try %d/%d)", addr, err, i, maxTries)


### PR DESCRIPTION
Currently OpenShardConn retries every time it encounters an error, regardless of whether it is context related or not, bloating the test log in case of TestContextsIntegration.

This PR changes the behavior of OpenShardConn, so it checks if context is done before trying to open a new connection, leaving immediately if it's done with appropriate error message.

Relates to #281, solving the context case, another PR will be made resolving the case of whether source port was busy or the error was something else.